### PR TITLE
Fix truncated text in long files

### DIFF
--- a/lib/rufo-atom.js
+++ b/lib/rufo-atom.js
@@ -48,7 +48,12 @@ export default {
     child.stdin.write(text);
     child.stdin.end();
 
-    child.stdout.on('data', function(data){
+    var data = '';
+    child.stdout.on('data', function(chunk) {
+      data += chunk;
+    });
+
+    child.stdout.on('end', function() {
       editor.setText(data.toString());
       editor.save();
     });


### PR DESCRIPTION
I found an issue when trying to format long files: data arrives asynchronously and using `setText`, it removes all present text and substitutes it with partial formatted date.