### PR TITLE
Don't set editor text on error

### DIFF
--- a/lib/rufo-atom.js
+++ b/lib/rufo-atom.js
@@ -54,8 +54,11 @@ export default {
     });
 
     child.stdout.on('end', function() {
-      editor.setText(data.toString());
-      editor.save();
+      var text = data.toString()
+      if (text !== "") {
+        editor.setText(text);
+        editor.save();
+      }
     });
 
     child.stderr.on('data', function(data){


### PR DESCRIPTION
When `stdout` emits an `end` event after `stderr` has emitted, `data.toString()` returns an empty string. For me, this causes the editor text to be cleared when `editor.setText()` after formatting fails due to a syntax error etc.  I'm assuming this is an issue in the underlying rufo binary emitting the wrong output, but this PR at least prevents the atom plugin from clearing out the editor text.

You could also set a `hasError` flag in `stderr` and check that, not sure what is best.